### PR TITLE
Add matrices tests, bring alphabets within function local scope

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ python:
 # command to install dependencies
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then travis_retry pip install -r requirements36.txt; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then travis_retry pip install -r requirements.txt; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then travis_retry pip install -r requirements37.txt; fi
 script:
   - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "3.6"
+  - "3.7"
+# command to install dependencies
+install:
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then travis_retry pip install -r requirements36.txt; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then travis_retry pip install -r requirements.txt; fi
+script:
+  - pytest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # pwseqdist
 
+[![Build Status](https://travis-ci.com/kmayerb/pwseqdist.svg?branch=matrices)](https://travis-ci.com/kmayerb/pwseqdist)
+
 A small package that efficiently computes distances between genetic sequences.
 Can accommodate similarity matrices, sequences of different lengths and custom
 metrics.

--- a/pwseqdist/matrices.py
+++ b/pwseqdist/matrices.py
@@ -72,7 +72,7 @@ def seq2vec(seq, alphabet = parasail_aa_alphabet_with_unknown ):
             vec[aai] =alphabet.index(aa)
         except ValueError("Unknown symbols given value for last column/row of matrix"):
             """Unknown symbols given value for last column/row of matrix"""
-            vec[aai] = len(parasail_aa_alphabet)
+            vec[aai] = len(alphabet)
     return vec
 
 def vec2seq(vec, alphabet = parasail_aa_alphabet_with_unknown  ):

--- a/pwseqdist/matrices.py
+++ b/pwseqdist/matrices.py
@@ -9,6 +9,7 @@ __all__ = ['parasail_aa_alphabet',
            'mat2seqs',
            'dict_from_matrix']
 
+
 """Parasail uses a 23 AA alphabet for its substitution matrix.
 A final column/row includes a value for any symbol not included
 in the alphabet"""
@@ -16,8 +17,10 @@ parasail_aa_alphabet = 'ARNDCQEGHILKMFPSTWYVBZX'
 """Used for reconstruction of sequences from number representation"""
 parasail_aa_alphabet_with_unknown = 'ARNDCQEGHILKMFPSTWYVBZX*'
 
-def dict_from_matrix(mat):
-    """Converts substitution matrix to a dict for use
+
+def dict_from_matrix(mat, alphabet = parasail_aa_alphabet):
+    """
+    Converts substitution matrix to a dict for use
     by str_subst_metric. Does not store (aa1, aa2) and
     (aa2, aa1), so user needs to check for both. Similarity
     for any symbol not present in the aplhabet is stored in
@@ -26,32 +29,109 @@ def dict_from_matrix(mat):
     Parameters
     ----------
     mat : parasail substitution Matrix object
-        Example is parasail.blosum62"""
-    d = {(aa1, aa2):mat.matrix[parasail_aa_alphabet.index(aa1), parasail_aa_alphabet.index(aa2)] for aa1, aa2 in itertools.product(parasail_aa_alphabet, parasail_aa_alphabet)}
+        Example is parasail.
+    alphabet : str
+        string of characters usely specifying the 23 AA Parasail 
+        uses for its substitution matrix.
+
+    Returns
+    -------
+    d : dict
+    """
+    d = {(aa1, aa2):mat.matrix[alphabet.index(aa1), alphabet.index(aa2)] for aa1, aa2 in itertools.product(alphabet, alphabet)}
     d.update({'na':mat.matrix[-1, 0]})
     return d
 
-def seq2vec(seq):
-    """Convert AA string sequence into numpy vector of integers"""
+def seq2vec(seq, alphabet = parasail_aa_alphabet_with_unknown ):
+    """
+    Convert AA string sequence into numpy vector of integers
+
+    Parameters
+    ----------
+    seq : string
+
+    alphabet : str
+        string of characters usely specifying the 23 AA Parasail 
+        uses for its substitution matrix.
+
+    Returns
+    -------
+    vec : np.ndarray
+
+    Examples 
+    -------_
+    >>> seq2vec("CAT")
+    array([ 4,  0, 16], dtype=int8)
+    >>> seq2vec("ARNDCQEGHILKMFPSTWYVBZX")
+    array([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
+       17, 18, 19, 20, 21, 22], dtype=int8)
+    """
     vec = np.zeros(len(seq), dtype=np.int8)
     for aai, aa in enumerate(seq):
         try:
-            vec[aai] = parasail_aa_alphabet.index(aa)
-        except ValueError:
+            vec[aai] =alphabet.index(aa)
+        except ValueError("Unknown symbols given value for last column/row of matrix"):
             """Unknown symbols given value for last column/row of matrix"""
             vec[aai] = len(parasail_aa_alphabet)
     return vec
 
-def vec2seq(vec):
-    """Convert a numpy array of integers back into a AA string sequence.
-    (opposite of seq2vec())"""
-    return ''.join([parasail_aa_alphabet_with_unknown[aai] for aai in vec])
+def vec2seq(vec, alphabet = parasail_aa_alphabet_with_unknown  ):
+    """
+    Convert a numpy array of integers back into a AA string sequence.
+    (opposite of seq2vec())
+    
+    Parameters
+    ----------
+    vec : np.array
+
+    alphabet : str
+        string of characters usely specifying the 23 AA Parasail 
+        uses for its substitution matrix.
+
+    Returns
+    -------
+    seq : string
+
+    Examples 
+    --------
+    >>> vec2seq([ 4,  0, 16])
+    'CAT'
+    """
+    try:
+        seq =  ''.join([alphabet[aai] for aai in vec])
+    except IndexError:
+        max_int = len(alphabet)-1
+        raise ValueError(f"vex2seq only works with integers 0 to {max_int} corresponding with {alphabet}")
+    return seq
 
 def seqs2mat(seqs):
-    """Convert a collection of AA sequences into a
+    """
+    Convert a collection of AA sequences into a
     numpy matrix of integers for fast comparison.
 
-    Requires all seqs to have the same length."""
+    Parameters
+    ----------
+    seqs : list 
+        list of strings of equal length
+
+    Returns
+    -------
+    mat : np.array  
+
+    Examples
+    --------
+    >>> seqs2mat(["CAT","HAT"])
+    array([[ 4,  0, 16],
+           [ 8,  0, 16]], dtype=int8)
+
+    Notes
+    -----
+
+    Requires all seqs to have the same length.
+
+    To avoid confusion, mat in this context is an np.array 
+    wherase mat in dict_from_matrix() is a parasail substitution Matrix object
+    """
     L1 = len(seqs[0])
     mat = np.zeros((len(seqs), L1), dtype=np.int8)
     for si, s in enumerate(seqs):
@@ -61,5 +141,23 @@ def seqs2mat(seqs):
     return mat
 
 def mat2seqs(mat):
-    """Convert a matrix of integers into AA sequences."""
-    return [vec2seq(mat[i,:]) for i in range(mat.shape[0])]
+    """
+    Convert a matrix of integers into AA sequences.
+    
+    Parameters
+    ----------
+    mat : np.array 
+        2D np.array of integers
+
+    Returns 
+    -------
+    seqs : list
+        list of strings
+    
+    Examples 
+    --------
+    >>> mat2seqs(np.array([[ 4,  0, 16],[ 8,  0, 16]] ))
+    ['CAT', 'HAT']
+    """
+    seqs = [vec2seq(mat[i,:]) for i in range(mat.shape[0])]
+    return seqs

--- a/pwseqdist/tests/test_matrices.py
+++ b/pwseqdist/tests/test_matrices.py
@@ -1,0 +1,59 @@
+import pwseqdist as pwsd
+import parasail
+import numpy as np
+import itertools
+import pytest
+
+def alphabet_oder():
+	assert pwsd.matrices.parasail_aa_alphabet == 'ARNDCQEGHILKMFPSTWYVBZX'
+
+def test_dict_from_matrix():
+
+	d = pwsd.matrices.dict_from_matrix(parasail.blosum62)
+	assert isinstance(d, dict)
+
+def test_dict_from_matrix_against_external_blossum_reference():
+	# See truth values: https://www.ncbi.nlm.nih.gov/books/NBK6831/figure/A551/
+	# ftp://ftp.ncbi.nlm.nih.gov/blast/matrices
+	d = pwsd.matrices.dict_from_matrix(parasail.blosum62)
+	assert isinstance(d, dict)
+	assert d[('X', 'V')] == -1
+	assert d[('A', 'A')] == 4
+	assert d[('N', 'N')] == 6
+	assert d[('W', 'W')] == 11
+	assert d[('D', 'W')] == -4
+	assert d[('W', 'D')] == -4
+	# No diagnol entries less than 4
+	assert np.all([d[(i, i)] >=4 for i in  pwsd.matrices.parasail_aa_alphabet if i != "X"] )
+	# No off diagnol entries greater than 4
+	assert np.all([d[(i[0], i[1])] <=4 for i in \
+	 itertools.product(pwsd.matrices.parasail_aa_alphabet, pwsd.matrices.parasail_aa_alphabet) if i[0] !=i[1]] )
+
+def test_seq2veq():
+	assert(isinstance(pwsd.matrices.seq2vec("CAT"), np.ndarray))
+
+def test_seq2veq():
+	assert np.all(pwsd.matrices.seq2vec("ARNDCQEGHILKMFPSTWYVBZX") == \
+		np.array([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,17, 18, 19, 20, 21, 22]))
+
+def test_vec2seq():
+    assert pwsd.matrices.vec2seq([ 4,  0, 16]) == 'CAT'
+
+def test_vec2seq_out_of_range_alph24():
+	with pytest.raises(ValueError) as ex:
+		pwsd.matrices.vec2seq([ 4,  0, 24], alphabet = pwsd.matrices.parasail_aa_alphabet_with_unknown )
+	print(ex.value)
+	assert str(ex.value) == 'vex2seq only works with integers 0 to 23 corresponding with ARNDCQEGHILKMFPSTWYVBZX*'
+
+def test_vec2seq_out_of_range_alph23():
+	with pytest.raises(ValueError) as ex:
+		pwsd.matrices.vec2seq([ 4,  0, 23], alphabet = pwsd.matrices.parasail_aa_alphabet )
+	print(ex.value)
+	assert str(ex.value) == 'vex2seq only works with integers 0 to 22 corresponding with ARNDCQEGHILKMFPSTWYVBZX'
+
+
+def test_seqs2mat():
+	assert np.all(pwsd.matrices.seqs2mat(["CAT","HAT"]) == np.array([[ 4,  0, 16],[ 8,  0, 16]]))
+    
+def test_mat2seqs():
+	assert np.all(pwsd.matrices.mat2seqs(np.array([[ 4,  0, 16],[ 8,  0, 16]]) ) == ['CAT', 'HAT'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+numpy==1.18.1
+pandas==1.0.0
+parasail==1.2
+parmap==1.5.2
+pytest==5.4.1
+scipy==1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ parasail==1.2
 parmap==1.5.2
 pytest==5.4.1
 scipy==1.4.1
+numba

--- a/requirements36.txt
+++ b/requirements36.txt
@@ -1,0 +1,6 @@
+numpy==1.16.4
+pandas==0.24.2
+parasail==1.1.17
+parmap==1.5.2
+pytest==5.0.0
+scipy==1.2.1

--- a/requirements36.txt
+++ b/requirements36.txt
@@ -4,3 +4,4 @@ parasail==1.1.17
 parmap==1.5.2
 pytest==5.0.0
 scipy==1.2.1
+numba

--- a/requirements37.txt
+++ b/requirements37.txt
@@ -4,3 +4,4 @@ parasail==1.2
 parmap==1.5.2
 pytest==5.4.1
 scipy==1.4.1
+numba


### PR DESCRIPTION
This pull request contains the following:
1. ` parasail_aa_alphabet` and `parasail_aa_alphabet_with_unknown` are passed as arguments into the local scope of relevant functions in` matrices.py`
2. Docstrings now contain simple examples
3. test_matrices includes some relevant unit tests.